### PR TITLE
update rest-client from 1.8 to 2.0.2

### DIFF
--- a/grafana-api.gemspec
+++ b/grafana-api.gemspec
@@ -10,5 +10,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/hartfordfive/ruby-grafana-api'
   s.license     = 'MIT'
   s.add_runtime_dependency 'json',         '~> 1.7'
-  s.add_runtime_dependency 'rest-client',  '~> 1.8'
+  s.add_runtime_dependency 'rest-client',  '~> 2.0.2'
 end


### PR DESCRIPTION
Updating the ``rest-client`` gem to resolve an [issue](https://github.com/rest-client/rest-client/issues/612) that was fixed in 2.0.1.